### PR TITLE
process.env fix

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,5 +19,4 @@ app.get('/user', async (req, res) => {
 
 app.listen(port, () => {
   console.log(`App listening on ${port}`);
-  // console.log(process.env.PG_PASS);
 });

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -1,11 +1,9 @@
 import knex from 'knex';
-import dotenv from 'dotenv';
+import './env';
 
 const knexfile = require('./knexfile');
-dotenv.config();
 
-// const env = process.env.NODE_ENV || 'development'; // <------problem here
-const env = 'development';
+const env = process.env.NODE_ENV || 'development';
 const configOptions = knexfile[env];
 
 export default knex(configOptions);

--- a/src/data/env.ts
+++ b/src/data/env.ts
@@ -1,0 +1,2 @@
+import dotenv from 'dotenv';
+dotenv.config();

--- a/src/data/knexfile.ts
+++ b/src/data/knexfile.ts
@@ -1,9 +1,5 @@
 // Update with your config settings.
-import dotenv from 'dotenv';
-
-dotenv.config();
-
-// const pgPass: string = process.env.PG_PASS;
+import './env';
 
 module.exports = {
   development: {
@@ -11,7 +7,7 @@ module.exports = {
     connection: {
       database: 'to_do_app',
       user: 'postgres',
-      password: process.env.PG_PASS, // <---------problem here
+      password: process.env.PG_PASS,
     },
     migrations: {
       directory: './migrations',


### PR DESCRIPTION
dotenv problem fixed
process.env.PG_PASS and process.env.NODE_ENV now have correct access to variables in .env file